### PR TITLE
add curl extension to the required section in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php" : "~5.6|~7.0",
+        "ext-curl": "*",
         "shieldfy/normalizer":"1.*"
     },
     "require-dev": {


### PR DESCRIPTION
make curl is required to be installed to allow folks from installing the sdk